### PR TITLE
Ignore 'return' from update_uri_parameters

### DIFF
--- a/minik/fields.py
+++ b/minik/fields.py
@@ -77,6 +77,9 @@ def update_uri_parameters(view_fn, request):
     try:
 
         for field_name, field_type in view_fn.__annotations__.items():
+            field_name == 'return':
+                #  Ignore 'return' field_name if type hint exists for view_fn
+                continue
             new_field_type = CUSTOM_FIELD_BY_TYPE.get(field_type, field_type)
             values_by_name[field_name] = new_field_type(values_by_name[field_name])
 


### PR DESCRIPTION
If type hints are added also as `return` of a function, `__annotations__` will get as `'return'` (per https://www.python.org/dev/peps/pep-3107/)
The field_name `'return'` should be ignored.